### PR TITLE
Label PRs automatically according to branch name

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,39 @@
+# Automatically apply labels based on PR source (head) branch name.
+# Each label corresponds to a commit/branch type defined in CONTRIBUTING.md.
+# Branch naming convention: <type>/<description>
+
+feature:
+  - head-branch: '^feat'
+
+improvement:
+  - head-branch: '^improve'
+
+bug:
+  - head-branch: '^fix'
+
+refactor:
+  - head-branch: '^refactor'
+
+style:
+  - head-branch: '^style'
+
+performance:
+  - head-branch: '^perf'
+
+test:
+  - head-branch: '^test'
+
+documentation:
+  - head-branch: '^docs'
+
+build:
+  - head-branch: '^build'
+
+devops:
+  - head-branch: '^devops'
+
+chore:
+  - head-branch: '^chore'
+
+revert:
+  - head-branch: '^revert'

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,18 @@
+name: Pull Request Labeler
+
+on:
+  pull_request_target:
+    types: [opened]
+
+jobs:
+  labeler:
+    name: Labeler
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !*.md
 !*.mk
 !*.tpp
+!*.yaml
 !.clang-format
 !.clang-tidy
 !.clang-uml


### PR DESCRIPTION
It will not work for this PR because the files need to be on the main branch, but I tested it in a private repo.