### PR TITLE
Add option to run cpp-linter manually without PR

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,10 +41,16 @@ Checks:
 CheckOptions:
   - key: bugprone-empty-catch.IgnoreCatchWithKeywords
     value: 'EMPTY: '
+  - key: misc-const-correctness.WarnPointersAsValues
+    value: true
+  - key: misc-const-correctness.TransformPointersAsValues
+    value: true
+  - key: misc-const-correctness.TransformPointersAsPointers
+    value: true
   - key: misc-header-include-cycle.IgnoredFilesList
     value: '.tpp' # pragma once does not seem to be recognized by clang-tidy.
   - key: modernize-deprecated-headers.CheckHeaderFile
-    value: 'true'
+    value: true
   - key: readability-magic-numbers.IgnoredIntegerValues
     value: '1;2;3;4;10' # 1-4 are default, 10 for decimal base operations.
   - key: readability-magic-numbers.IgnoredFloatingPointValues

--- a/.github/workflows/cpp-linter.yaml
+++ b/.github/workflows/cpp-linter.yaml
@@ -9,6 +9,7 @@ on:
   push:
     branches: [main, master]
     paths: ['**.c', '**.cpp', '**.h', '**.hpp', '**.ipp', '**.tpp', '**/CMake*', '**.cmake', '**/Makefile', '**.mk', '**/.clang-*', '**/cpp-linter.yaml']
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
It's useful to test something on a branch that might not become a PR, or just to debug the linter.

---

**1. Go to "Actions":**
   <img width="496" height="69" alt="image" src="https://github.com/user-attachments/assets/02b6bf5a-2fd7-494a-9ba1-73e76a38a2e2" />
---
**2. Choose the workflow:**
   <img width="497" height="392" alt="image" src="https://github.com/user-attachments/assets/b6d152a6-7c0d-4679-ae27-cec637da13e3" />
---
**3. Click "Run workflow":**
   <img width="1049" height="277" alt="image" src="https://github.com/user-attachments/assets/b8d65fc8-e484-4268-957f-adeaebd66385" />
---
**4. Choose the branch:**
   <img width="434" height="240" alt="image" src="https://github.com/user-attachments/assets/51559c8b-f1ee-4fab-93c1-f80fe3d2d758" />
---