### PR TITLE
Add `contains()` and `contains_subrange()` to libftpp

### DIFF
--- a/lib/libftpp/libftpp/algorithm.hpp
+++ b/lib/libftpp/libftpp/algorithm.hpp
@@ -6,6 +6,22 @@
 #	include <iterator>
 #	include <utility>
 
+/**
+ * About Ranges
+ *
+ * Some functions support "ranges" as arguments.
+ * Ranges are not implemented specially like in C++20.
+ * A range for libftpp is any type that has public `begin()` and `end()` member
+ * functions and `iterator` and `const_iterator` typedefs, or a bounded array.
+ *
+ * Limitations:
+ * - No concepts are used to constrain template parameters.
+ * - Projections are not supported.
+ * - Functions are not implemented as algorithm function objects (AFOs).
+ *
+ * https://en.cppreference.com/w/cpp/algorithm/ranges
+ */
+
 #	define FT_MIN(a, b) ((b) < (a) ? (b) : (a))
 #	define FT_MAX(a, b) ((b) > (a) ? (b) : (a))
 
@@ -16,6 +32,8 @@ namespace ft {
  */
 template <typename InputIt, typename T>
 bool contains(InputIt first, InputIt last, const T& value);
+template <typename R, typename T>
+bool contains(const R& r, const T& value);
 
 /**
  * https://en.cppreference.com/w/cpp/algorithm/ranges/contains
@@ -25,6 +43,8 @@ bool contains_subrange(InputIt1 first1,
                        InputIt1 last1,
                        InputIt2 first2,
                        InputIt2 last2);
+template <typename R1, typename R2>
+bool contains_subrange(const R1& r1, const R2& r2);
 
 /**
  * https://en.cppreference.com/w/cpp/algorithm/copy

--- a/lib/libftpp/libftpp/algorithm/contains.tpp
+++ b/lib/libftpp/libftpp/algorithm/contains.tpp
@@ -4,6 +4,7 @@
 #	define LIBFTPP_ALGORITHM_CONTAINS_TPP
 
 #	include "libftpp/algorithm.hpp"
+#	include "libftpp/iterator.hpp"
 #	include <algorithm>
 
 namespace ft {
@@ -14,6 +15,12 @@ bool contains(InputIt first, InputIt last, const T& value)
 	return std::find(first, last, value) != last;
 }
 
+template <typename R, typename T>
+bool contains(const R& r, const T& value)
+{
+	return ft::contains(ft::begin(r), ft::end(r), value);
+}
+
 template <typename InputIt1, typename InputIt2>
 bool contains_subrange(InputIt1 first1,
                        InputIt1 last1,
@@ -22,6 +29,13 @@ bool contains_subrange(InputIt1 first1,
 {
 	return first2 == last2
 	       || std::search(first1, last1, first2, last2) != last1;
+}
+
+template <typename R1, typename R2>
+bool contains_subrange(const R1& r1, const R2& r2)
+{
+	return ft::contains_subrange(
+	    ft::begin(r1), ft::end(r1), ft::begin(r2), ft::end(r2));
 }
 
 } // namespace ft


### PR DESCRIPTION
Also gives guidelines and a precedent how to implement algorithms taking a range instead of iterator pairs.