### PR TITLE
Disable `cpp-linter` review comments

### DIFF
--- a/.github/workflows/cpp-linter.yaml
+++ b/.github/workflows/cpp-linter.yaml
@@ -37,6 +37,7 @@ jobs:
           version: '20'
           files-changed-only: false # Changes in header files can affect other files.
           ignore: 'build'
+          thread-comments: true
           step-summary: true
           database: 'build'
           tidy-review: true


### PR DESCRIPTION
If something goes wrong one time (like not compilable) cpp-linter posts a ton of review comments. They cannot be easily batch deleted or resolved.
This makes it quite annoying to use the GitHub Pull Requests VS Code extension.

As a replacement, post the job summary in the PR. The comment will always get updated and, once resolved, deleted.