### PR TITLE
Fix compilation with C++ standards post C++03 (like our tests)

### DIFF
--- a/lib/libftpp/libftpp/memory.hpp
+++ b/lib/libftpp/libftpp/memory.hpp
@@ -13,6 +13,11 @@
 #	include <memory>
 #	include <ostream>
 
+#	if __cplusplus < 201103L
+// Stop support with C++11 to avoid deprecation warnings.
+#		define LIBFTPP_SUPPORT_AUTO_PTR 1
+#	endif // __cplusplus < 201103L
+
 namespace ft {
 
 /* default_delete */
@@ -130,7 +135,7 @@ public:
 	                   && _unique_ptr::is_compatible_deleter<E, Deleter>::value,
 	               _enabler>::type /*unused*/
 	           = _enabler()) throw();
-#	if __cplusplus <= 201402L
+#	if LIBFTPP_SUPPORT_AUTO_PTR
 	// 8)
 	template <typename U>
 	unique_ptr(ft::rvalue<std::auto_ptr<U> >& u,
@@ -139,7 +144,7 @@ public:
 	                   && ft::is_same<Deleter, default_delete<T> >::value,
 	               _enabler>::type /*unused*/
 	           = _enabler()) throw();
-#	endif // __cplusplus <= 201402L
+#	endif // LIBFTPP_SUPPORT_AUTO_PTR
 	// NOLINTEND(google-explicit-constructor)
 	~unique_ptr();
 	unique_ptr& operator=(ft::rvalue<unique_ptr>& r) throw();
@@ -561,14 +566,14 @@ public:
 	               _shared_ptr::is_compatible_smart_pointer<Y, T>::value,
 	               _enabler>::type /*unused*/
 	           = _enabler()) throw();
-#	if __cplusplus <= 201402L
+#	if LIBFTPP_SUPPORT_AUTO_PTR
 	// 12)
 	template <typename Y>
 	shared_ptr(ft::rvalue<std::auto_ptr<Y> >& r,
 	           typename ft::enable_if<ft::is_convertible<Y*, T*>::value,
 	                                  _enabler>::type /*unused*/
 	           = _enabler());
-#	endif // __cplusplus <= 201402L
+#	endif // LIBFTPP_SUPPORT_AUTO_PTR
 	// 13)
 	template <typename Y, typename Deleter>
 	shared_ptr(

--- a/lib/libftpp/libftpp/memory/shared_ptr.tpp
+++ b/lib/libftpp/libftpp/memory/shared_ptr.tpp
@@ -160,7 +160,7 @@ shared_ptr<T>::shared_ptr(
 	r._control = FT_NULLPTR;
 }
 
-#	if __cplusplus <= 201402L
+#	if LIBFTPP_SUPPORT_AUTO_PTR
 // 12)
 template <typename T>
 template <typename Y>
@@ -175,7 +175,7 @@ shared_ptr<T>::shared_ptr(
 {
 	r.release();
 }
-#	endif // __cplusplus <= 201402L
+#	endif // LIBFTPP_SUPPORT_AUTO_PTR
 
 // 13)
 template <typename T>

--- a/lib/libftpp/libftpp/memory/unique_ptr.tpp
+++ b/lib/libftpp/libftpp/memory/unique_ptr.tpp
@@ -100,7 +100,7 @@ unique_ptr<T, Deleter>::unique_ptr(
                                           : ft::move(u.get_deleter()))
 {}
 
-#	if __cplusplus <= 201402L
+#	if LIBFTPP_SUPPORT_AUTO_PTR
 // 8)
 template <typename T, typename Deleter /*= default_delete<T> */>
 template <typename U>
@@ -113,7 +113,7 @@ unique_ptr<T, Deleter>::unique_ptr(
     : _ptr(u.release()),
       _deleter()
 {}
-#	endif // __cplusplus <= 201402L
+#	endif // LIBFTPP_SUPPORT_AUTO_PTR
 
 template <typename T, typename Deleter /*= default_delete<T> */>
 unique_ptr<T, Deleter>::~unique_ptr()


### PR DESCRIPTION
Because our tests are not compiled with `-std=c++98`, `std::auto_ptr` caused deprecation warnings with `g++`.
`-Werror` then caused compilation to fail.

From now on, libftpp stops supporting `std::auto_ptr` with C++11.