### PR TITLE
Ensure `Logger` is exception-safe

### DIFF
--- a/src/utils/logger/Logger.cpp
+++ b/src/utils/logger/Logger.cpp
@@ -36,15 +36,15 @@ Logger& Logger::getInstance(const char* filename) throw()
   }
 }
 
-Logger::FileStream& Logger::info()
+std::ostream& Logger::info()
 {
   return _log(INFO);
 }
-Logger::FileStream& Logger::warning()
+std::ostream& Logger::warning()
 {
   return _log(WARNING);
 }
-Logger::FileStream& Logger::error()
+std::ostream& Logger::error()
 {
   return _log(ERROR);
 }
@@ -53,16 +53,16 @@ Logger::FileStream& Logger::error()
 // PRIVATE
 Logger::Logger(const std::string& filename)
 {
-  _file._stream.open(filename.c_str(), std::ios::out | std::ios::trunc);
+  _file.open(filename.c_str(), std::ios::out | std::ios::trunc);
   _file << std::unitbuf; // enables automatic flush
-  if (!_file._stream) {
+  if (!_file) {
     std::cerr << "Failed to open log file: " << filename << '\n';
   }
 }
 
-Logger::FileStream& Logger::_log(LogLevel level)
+std::ostream& Logger::_log(LogLevel level)
 {
-  if (!_file._stream.is_open()) {
+  if (!_file.is_open()) {
     return _file;
   }
   std::string levelStr;

--- a/src/utils/logger/Logger.hpp
+++ b/src/utils/logger/Logger.hpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <map>
+#include <ostream>
 #include <string>
 
 #define LOG_GENERAL "./log/general.log"
@@ -14,15 +15,12 @@
 /* ************************************************************************** */
 class Logger
 {
-private:
-  class FileStream;
-
 public:
   static Logger& getInstance(const char* filename) throw();
 
-  FileStream& info();
-  FileStream& warning();
-  FileStream& error();
+  std::ostream& info();
+  std::ostream& warning();
+  std::ostream& error();
 
   ~Logger() {}
 
@@ -36,36 +34,18 @@ private:
     ERROR
   };
 
-  class FileStream
-  {
-  public:
-    template<typename T>
-    FileStream& operator<<(const T& msg);
-
-  private:
-    friend class Logger;
-    std::ofstream _stream;
-  };
-
   Logger() throw() {}
   explicit Logger(const std::string& filename);
   Logger(const Logger& other);
   Logger& operator=(const Logger& other);
 
-  FileStream& _log(LogLevel level);
+  std::ostream& _log(LogLevel level);
   static InstanceMap& _instances();
   static std::string _currentTime();
 
   static const int _widthLevelStr = 7;
 
-  FileStream _file;
+  std::ofstream _file;
 };
-
-template<typename T>
-Logger::FileStream& Logger::FileStream::operator<<(const T& msg)
-{
-  _stream << msg;
-  return *this;
-}
 
 #endif


### PR DESCRIPTION
**Fixes:**
- Ensure `Logger` is exception-safe.
- Compare filenames in map, not addresses.
  `const char*` in a `std::map` compares addresses, not strings.
  Two strings (`const char*`) with the same filename can have different addresses, creating multiple logger instances for the same file in the map.

**Refactor:**
- Remove redundant destructor.