### PR TITLE
Change filenames for case-insensitive filesystems (like macOS)

### DIFF
--- a/tests/assets/valid/bodysize_multiplier_B.conf
+++ b/tests/assets/valid/bodysize_multiplier_B.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1024B;
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multiplier_G.conf
+++ b/tests/assets/valid/bodysize_multiplier_G.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1G;
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multiplier_K.conf
+++ b/tests/assets/valid/bodysize_multiplier_K.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1K;
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multiplier_M.conf
+++ b/tests/assets/valid/bodysize_multiplier_M.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1M;
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multiplier_b.conf
+++ b/tests/assets/valid/bodysize_multiplier_b.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1024b; #b for bytes
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multiplier_g.conf
+++ b/tests/assets/valid/bodysize_multiplier_g.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1g;
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multiplier_k.conf
+++ b/tests/assets/valid/bodysize_multiplier_k.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1k;
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multiplier_m.conf
+++ b/tests/assets/valid/bodysize_multiplier_m.conf
@@ -1,9 +1,0 @@
-root /var/www/;
-max_body_size 1m;
-keepalive_timeout 60;
-
-server
-{
-  listen 8080;
-  server_name serv1;
-}

--- a/tests/assets/valid/bodysize_multipliers.conf
+++ b/tests/assets/valid/bodysize_multipliers.conf
@@ -1,0 +1,58 @@
+root /var/www/;
+keepalive_timeout 60;
+
+server
+{
+  listen 8081;
+  server_name serv_b;
+  max_body_size 1b;
+}
+
+server
+{
+  listen 8082;
+  server_name serv_B;
+  max_body_size 2B;
+}
+
+server
+{
+  listen 8083;
+  server_name serv_k;
+  max_body_size 3k;
+}
+
+server
+{
+  listen 8084;
+  server_name serv_K;
+  max_body_size 4K;
+}
+
+server
+{
+  listen 8085;
+  server_name serv_m;
+  max_body_size 5m;
+}
+
+server
+{
+  listen 8086;
+  server_name serv_M;
+  max_body_size 6M;
+}
+
+server
+{
+  listen 8087;
+  server_name serv_g;
+  max_body_size 7g;
+}
+
+server
+{
+  listen 8088;
+  server_name serv_G;
+  max_body_size 8G;
+}

--- a/tests/config/configParserTester.cpp
+++ b/tests/config/configParserTester.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 using config::Config;
 using config::ConfigParser;
@@ -657,76 +658,33 @@ TEST(SyntaxErrorsTester, SemicolonBeforeDirective)
 // Valid Config Tests
 // ============================================================================
 
-TEST(ValidConfigTester, BodySizeMultiplier_b)
+TEST(ValidConfigTester, BodySizeMultipliers)
 {
   const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_b.conf";
+    std::string(ASSETS_PATH) + "valid/bodysize_multipliers.conf";
   ConfigParser parser(configPath.c_str());
   Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
-}
+  ASSERT_NO_THROW(config = parser.parseConfig());
 
-TEST(ValidConfigTester, BodySizeMultiplier_B)
-{
-  const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_B.conf";
-  ConfigParser parser(configPath.c_str());
-  Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
-}
+  const std::vector<ServerConfig>& servers = config.getServers();
+  ASSERT_EQ(servers.size(), 8);
 
-TEST(ValidConfigTester, BodySizeMultiplier_g)
-{
-  const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_g.conf";
-  ConfigParser parser(configPath.c_str());
-  Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
-}
-
-TEST(ValidConfigTester, BodySizeMultiplier_G)
-{
-  const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_G.conf";
-  ConfigParser parser(configPath.c_str());
-  Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
-}
-
-TEST(ValidConfigTester, BodySizeMultiplier_k)
-{
-  const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_k.conf";
-  ConfigParser parser(configPath.c_str());
-  Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
-}
-
-TEST(ValidConfigTester, BodySizeMultiplier_K)
-{
-  const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_K.conf";
-  ConfigParser parser(configPath.c_str());
-  Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
-}
-
-TEST(ValidConfigTester, BodySizeMultiplier_m)
-{
-  const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_m.conf";
-  ConfigParser parser(configPath.c_str());
-  Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
-}
-
-TEST(ValidConfigTester, BodySizeMultiplier_M)
-{
-  const std::string configPath =
-    std::string(ASSETS_PATH) + "valid/bodysize_multiplier_M.conf";
-  ConfigParser parser(configPath.c_str());
-  Config config;
-  EXPECT_NO_THROW(config = parser.parseConfig());
+  // b (bytes)
+  EXPECT_EQ(servers[0].getMaxBodySize(), 1UL);
+  // B (bytes)
+  EXPECT_EQ(servers[1].getMaxBodySize(), 2UL);
+  // k (kilobytes)
+  EXPECT_EQ(servers[2].getMaxBodySize(), 3UL * 1024);
+  // K (kilobytes)
+  EXPECT_EQ(servers[3].getMaxBodySize(), 4UL * 1024);
+  // m (megabytes)
+  EXPECT_EQ(servers[4].getMaxBodySize(), 5UL * 1024 * 1024);
+  // M (megabytes)
+  EXPECT_EQ(servers[5].getMaxBodySize(), 6UL * 1024 * 1024);
+  // g (gigabytes)
+  EXPECT_EQ(servers[6].getMaxBodySize(), 7UL * 1024 * 1024 * 1024);
+  // G (gigabytes)
+  EXPECT_EQ(servers[7].getMaxBodySize(), 8UL * 1024 * 1024 * 1024);
 }
 
 TEST(ValidConfigTester, CommentsInValue)


### PR DESCRIPTION
All tests were able to be combined into one file since they should all be valid.