### PR TITLE
Add tests for Content-Length validation

### DIFF
--- a/tests/http/states/readBodyTester.cpp
+++ b/tests/http/states/readBodyTester.cpp
@@ -221,7 +221,7 @@ TEST(ReadBodyTester, ChunkedSpecialBytes)
   EXPECT_EQ(body, expectedData);
 }
 
-TEST(ReadBodyTester, FixedLengthInvalid)
+TEST(ReadBodyTester, FixedLengthContentLengthTooLarge)
 {
   const std::string line("0123456789\r\n");
 
@@ -234,13 +234,45 @@ TEST(ReadBodyTester, FixedLengthInvalid)
   EXPECT_EQ(response.getStatusCode(), StatusCode::ContentTooLarge);
 }
 
-// TODO add when content-length grama available
-TEST(ReadBodyTester, DISABLED_FixedLengthInvalid)
+TEST(ReadBodyTester, ChunkedChunkSizeInvalid)
 {
-  const std::string line("0123456789\r\n");
+  const std::string line("a a\r\n"
+                         "0123456789\r\n"
+                         "0\r\n"
+                         "\r\n");
 
   const ft::unique_ptr<Client> client = ft::make_unique<Client>();
-  client->getRequest().getHeaders().addHeader("Content-Length", "10 afdadf");
+  client->getRequest().getHeaders().addHeader("Transfer-Encoding", "chunked");
+  StateTest(*client, line);
+  const Response& response = client->getResponse();
+
+  EXPECT_EQ(response.getStatusCode(), StatusCode::BadRequest);
+}
+
+TEST(ReadBodyTester, ChunkedChunkSizeInvalidHex)
+{
+  const std::string line("G\r\n"
+                         "0123456789\r\n"
+                         "0\r\n"
+                         "\r\n");
+
+  const ft::unique_ptr<Client> client = ft::make_unique<Client>();
+  client->getRequest().getHeaders().addHeader("Transfer-Encoding", "chunked");
+  StateTest(*client, line);
+  const Response& response = client->getResponse();
+
+  EXPECT_EQ(response.getStatusCode(), StatusCode::BadRequest);
+}
+
+TEST(ReadBodyTester, ChunkedChunkSizeNegative)
+{
+  const std::string line("-5\r\n"
+                         "0123456789\r\n"
+                         "0\r\n"
+                         "\r\n");
+
+  const ft::unique_ptr<Client> client = ft::make_unique<Client>();
+  client->getRequest().getHeaders().addHeader("Transfer-Encoding", "chunked");
   StateTest(*client, line);
   const Response& response = client->getResponse();
 

--- a/tests/http/states/readHeaderLinesTester.cpp
+++ b/tests/http/states/readHeaderLinesTester.cpp
@@ -144,10 +144,32 @@ TEST(ReadHeaderLinesTester, TransferEncAndContentLen)
   EXPECT_EQ(statusCode, StatusCode::BadRequest);
 }
 
-TEST(ReadHeaderLinesTester, InvalidContentLength)
+TEST(ReadHeaderLinesTester, InvalidContentLengthNonNumeric)
 {
   std::string line("TestHeader1: hi\r\n"
                    "Content-Length: 7a\r\n"
+                   "\r\n");
+  ft::unique_ptr<Client> client = StateTest(line);
+  Response& response = client->getResponse();
+  const StatusCode& statusCode = response.getStatusCode();
+  EXPECT_EQ(statusCode, StatusCode::BadRequest);
+}
+
+TEST(ReadHeaderLinesTester, InvalidContentLengthMultipleValues)
+{
+  std::string line("TestHeader1: hi\r\n"
+                   "Content-Length: 10 10\r\n"
+                   "\r\n");
+  ft::unique_ptr<Client> client = StateTest(line);
+  Response& response = client->getResponse();
+  const StatusCode& statusCode = response.getStatusCode();
+  EXPECT_EQ(statusCode, StatusCode::BadRequest);
+}
+
+TEST(ReadHeaderLinesTester, NegativeContentLength)
+{
+  std::string line("TestHeader1: hi\r\n"
+                   "Content-Length: -10\r\n"
                    "\r\n");
   ft::unique_ptr<Client> client = StateTest(line);
   Response& response = client->getResponse();


### PR DESCRIPTION
Also enable a disabled test - moved to a different tester though. Removes a TODO comment.