### PR TITLE
Silence valgrind on `execve()` fail

### DIFF
--- a/src/http/statesCgi/executeCgi/ExecuteCgi.cpp
+++ b/src/http/statesCgi/executeCgi/ExecuteCgi.cpp
@@ -214,7 +214,9 @@ try {
   } catch (...) {
     // EMPTY: Exit in all cases.
   }
-  std::exit(EXIT_FAILURE);
+  ::close(STDIN_FILENO);
+  ::close(STDOUT_FILENO);
+  throw EXIT_FAILURE;
 }
 // NOLINTEND(cppcoreguidelines-pro-type-const-cast)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,8 @@ try {
 } catch (const std::exception& e) {
   std::cerr << "Error: " << e.what() << '\n';
   return EXIT_FAILURE;
+} catch (...) {
+  return EXIT_FAILURE;
 }
 // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 


### PR DESCRIPTION
It's a little bit stupid and unnecessary but better not get into any arguments during the eval.