### PR TITLE
Use default config path when no argument provided

### DIFF
--- a/assets/errors/400.html
+++ b/assets/errors/400.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>403 Forbidden</title>
+  <title>400 Bad Request</title>
   <style>
     body {
       font-family: system-ui, sans-serif;
@@ -26,7 +26,7 @@
 </head>
 
 <body>
-  <h1>403 Forbidden</h1>
+  <h1>400 Bad Request</h1>
 </body>
 
 </html>

--- a/assets/testWebsite/default.conf
+++ b/assets/testWebsite/default.conf
@@ -1,0 +1,64 @@
+# =====================================================
+# Global config (Config)
+# =====================================================
+
+root ./assets/testWebsite/;
+max_body_size 8192;
+keepalive_timeout 60;
+
+error_page 400 ./assets/errors/400.html;
+error_page 403 ./assets/errors/403.html;
+error_page 404 ./assets/errors/404.html;
+error_page 502 ./assets/errors/502.html;
+
+# =====================================================
+# Server 1
+# =====================================================
+
+server {
+    listen 8080;
+    server_name localhost;
+
+    location /old/ {
+        root ./assets/testWebsite/old/;
+        redirect true;
+        redirect_code 307;
+        redirect_url http://localhost:8080/new/;
+    }
+
+    location /new/ {
+        root ./assets/testWebsite/new/;
+        allowed_methods GET POST;
+    }
+
+    # "Shadow" location:
+    location /new-files/ {
+        root ./assets/testWebsite/new/;
+        autoindex on;
+        index non_existent_file; # Force autoindex by defining a missing index
+        allowed_methods GET DELETE;
+    }
+
+    location /upload/ {
+        root ./assets/testWebsite/upload/;
+        autoindex on;
+        allowed_methods GET POST;
+        max_body_size 100;
+    }
+
+    location /delete/ {
+        root ./assets/testWebsite/upload/;
+        autoindex on;
+        allowed_methods DELETE;
+    }
+
+    location /cgi-bin/ {
+        root ./assets/testWebsite/cgi-bin/;
+        autoindex off;
+        allowed_methods GET POST;
+        cgi_enabled yes;
+        cgi_pass /bin/bash;
+        cgi_extension .sh;
+        max_body_size 20000;
+    }
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,8 @@
 
 static void initSingletons();
 
-const char* const defaultConfigPath = "./assets/testWebsite/default.conf";
+static const char* const defaultConfigPath =
+  "./assets/testWebsite/default.conf";
 
 // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic): argv.
 int main(int argc, char* argv[])
@@ -25,8 +26,12 @@ try {
     return EXIT_FAILURE;
   }
 
-  const char* const configPath = (argc == 2) ? argv[1] : defaultConfigPath;
-  logger.info() << "parsing config in \"" << configPath << "\"...\n";
+  const char* const configPath = (argc == 1) ? defaultConfigPath : argv[1];
+  if (argc == 1) {
+    std::cout << "Using default configuration file: " << configPath << '\n';
+  } else {
+    std::cout << "Using configuration file: " << configPath << '\n';
+  }
   config::ConfigParser(configPath).parseConfig();
   std::cout << Config::getConfig();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,18 +13,21 @@
 
 static void initSingletons();
 
+const char* const defaultConfigPath = "TODO.conf"; // TODO
+
 // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic): argv.
 int main(int argc, char* argv[])
 try {
   Logger& logger = Logger::getInstance(LOG_GENERAL);
 
-  if (argc != 2) {
-    std::cerr << "Usage: " << argv[0] << " <configuration file>\n";
+  if (argc > 2) {
+    std::cerr << "Usage: " << argv[0] << " [configuration file]\n";
     return EXIT_FAILURE;
   }
 
-  logger.info() << "parsing config...\n";
-  config::ConfigParser(argv[1]).parseConfig();
+  const char* const configPath = (argc == 2) ? argv[1] : defaultConfigPath;
+  logger.info() << "parsing config in \"" << configPath << "\"...\n";
+  config::ConfigParser(configPath).parseConfig();
   std::cout << Config::getConfig();
 
   initSingletons();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,7 +13,7 @@
 
 static void initSingletons();
 
-const char* const defaultConfigPath = "TODO.conf"; // TODO
+const char* const defaultConfigPath = "./assets/testWebsite/default.conf";
 
 // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic): argv.
 int main(int argc, char* argv[])


### PR DESCRIPTION
When more than one argument was given still fail with a usage message.